### PR TITLE
fix: add missing includes

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -22,5 +22,5 @@ jobs:
               echo "Invalid: $msg"
               failed=1
             fi
-          done < <(git log origin/main..HEAD --format="%s")
+          done < <(git log origin/main..HEAD --no-merges --format="%s")
           exit $failed

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,6 +36,7 @@ jobs:
           -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
           -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
           -DCMAKE_BUILD_TYPE=Release
+          -DFETCHCONTENT_SOURCE_DIR_AESIMULTIPRECISION=${{ github.workspace }}
           -S ${{ github.workspace }}/ci/integration
 
       - name: Build

--- a/Aeu.h
+++ b/Aeu.h
@@ -32,6 +32,7 @@
 #define AEU_MULTIPRECISION
 
 /// @cond HIDE_INCLUDES
+#include <cstdint>
 #include <iostream>
 #include <cassert>
 

--- a/Aeu.h
+++ b/Aeu.h
@@ -33,6 +33,8 @@
 
 /// @cond HIDE_INCLUDES
 #include <cstdint>
+#include <cctype>
+#include <cwctype>
 #include <iostream>
 #include <cassert>
 


### PR DESCRIPTION
uint8_t, uint32_t, and uint64_t were available transitively through <iostream> on some compilers but not on clang/gcc when the header is consumed via FetchContent as a standalone library, causing Build and Integration CI jobs to fail.