### PR TITLE
chore: pin FetchContent dependencies to specific release tags

### DIFF
--- a/ci/integration/CMakeLists.txt
+++ b/ci/integration/CMakeLists.txt
@@ -16,7 +16,7 @@ target_link_libraries(Library_Integration PRIVATE AesiMultiprecision)
 # 2. Test examples from README with GTest
 FetchContent_Declare(googletest
         GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG main
+        GIT_TAG v1.17.0
 )
 FetchContent_MakeAvailable(googletest)
 

--- a/sanitize/unsigned/CMakeLists.txt
+++ b/sanitize/unsigned/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 20)
 include(FetchContent)
 FetchContent_Declare(primesieve
         GIT_REPOSITORY https://github.com/kimwalisch/primesieve.git
-        GIT_TAG master
+        GIT_TAG v12.14
         GIT_SHALLOW TRUE)
 FetchContent_MakeAvailable(primesieve)
 


### PR DESCRIPTION
googletest: main → v1.17.0
primesieve: master → v12.14

Floating branch tags break silently when upstream makes breaking changes.