### PR TITLE
refactor: move googletest fetch to root CMake, pin to v1.17.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,13 @@ option(AESI_BUILD_BENCHMARKS "Build benchmarks"  OFF)
 option(AESI_BUILD_SANITIZERS "Build sanitizers"  OFF)
 
 if(AESI_BUILD_TESTS)
+    include(FetchContent)
+    FetchContent_Declare(googletest
+            GIT_REPOSITORY https://github.com/google/googletest.git
+            GIT_TAG v1.17.0
+            GIT_SHALLOW TRUE)
+    FetchContent_MakeAvailable(googletest)
+    enable_testing()
     add_subdirectory(test)
 endif()
 if(AESI_BUILD_BENCHMARKS)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,14 +2,15 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     cmake_minimum_required(VERSION 3.26)
     project(AesiMultiprecision)
     set(CMAKE_CXX_STANDARD 20)
-endif()
 
-include(FetchContent)
-FetchContent_Declare(
-        googletest
-        URL https://github.com/google/googletest/archive/refs/heads/main.zip
-)
-FetchContent_MakeAvailable(googletest)
+    include(FetchContent)
+    FetchContent_Declare(googletest
+            GIT_REPOSITORY https://github.com/google/googletest.git
+            GIT_TAG v1.17.0
+            GIT_SHALLOW TRUE)
+    FetchContent_MakeAvailable(googletest)
+    enable_testing()
+endif()
 
 find_package(PkgConfig)
 pkg_check_modules(GMP REQUIRED IMPORTED_TARGET gmp)


### PR DESCRIPTION
Previously googletest was fetched independently in test/CMakeLists.txt via a floating URL (refs/heads/main.zip). Now:
- Root CMakeLists.txt fetches googletest once under AESI_BUILD_TESTS, pinned to v1.17.0 with GIT_SHALLOW for faster CI
- test/CMakeLists.txt keeps the fetch only inside the standalone guard for direct invocation of test/ as a standalone project, also pinned

Consistent with the v1.17.0 tag already used in ci/integration/.