### PR TITLE
ci: add CUDA compile-only workflow

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -1,0 +1,39 @@
+name: CUDA Compile
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'include/**'
+      - 'ci/cuda/**'
+      - '.github/workflows/cuda.yml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'include/**'
+      - 'ci/cuda/**'
+      - '.github/workflows/cuda.yml'
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    container: nvidia/cuda:12.6.0-devel-ubuntu24.04
+
+    steps:
+      - name: Install dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: apt-get update && apt-get install -y cmake git
+
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -B ${{ github.workspace }}/ci/cuda/cmake-build
+          -DCMAKE_CUDA_COMPILER=nvcc
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_CUDA_ARCHITECTURES=80
+          -DFETCHCONTENT_SOURCE_DIR_AESIMULTIPRECISION=${{ github.workspace }}
+          -S ${{ github.workspace }}/ci/cuda
+
+      - name: Build
+        run: cmake --build ${{ github.workspace }}/ci/cuda/cmake-build -j8

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -17,15 +17,14 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
-    container: nvidia/cuda:12.6.0-devel-ubuntu24.04
 
     steps:
-      - name: Install dependencies
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: apt-get update && apt-get install -y cmake git
-
       - uses: actions/checkout@v4
+
+      - name: Install CUDA toolkit
+        uses: Jimver/cuda-toolkit@v0.2.22
+        with:
+          cuda: '12.6.0'
 
       - name: Configure
         run: cmake -B ${{ github.workspace }}/ci/cuda/cmake-build

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /cmake-build-debug/
 /cmake-build-tests/
 .idea/
+ci/cuda/cmake-build/

--- a/ci/cuda/CMakeLists.txt
+++ b/ci/cuda/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.26)
+project(AesiCudaSmoke LANGUAGES CXX CUDA)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CUDA_STANDARD 20)
+
+include(FetchContent)
+FetchContent_Declare(AesiMultiprecision
+        GIT_REPOSITORY https://github.com/Alvov1/Aesi-Multiprecision.git
+        GIT_TAG main)
+FetchContent_MakeAvailable(AesiMultiprecision)
+
+add_executable(AesiCudaSmoke smoke.cu)
+target_link_libraries(AesiCudaSmoke PRIVATE AesiMultiprecision)

--- a/ci/cuda/CMakeLists.txt
+++ b/ci/cuda/CMakeLists.txt
@@ -12,3 +12,5 @@ FetchContent_MakeAvailable(AesiMultiprecision)
 
 add_executable(AesiCudaSmoke smoke.cu)
 target_link_libraries(AesiCudaSmoke PRIVATE AesiMultiprecision)
+target_compile_options(AesiCudaSmoke PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-Wall,-Wextra,-Werror>)

--- a/ci/cuda/smoke.cu
+++ b/ci/cuda/smoke.cu
@@ -1,0 +1,51 @@
+#include <AesiMultiprecision/Aeu.h>
+#include <AesiMultiprecision/Aesi.h>
+
+template <std::size_t Bits>
+__global__ void unsignedKernel(const Aeu<Bits>* a, const Aeu<Bits>* b, Aeu<Bits>* out) {
+    *out = *a + *b;
+    *out *= *b;
+}
+
+template <std::size_t Bits>
+__global__ void signedKernel(const Aesi<Bits>* a, const Aesi<Bits>* b, Aesi<Bits>* out) {
+    *out = *a + *b;
+    *out *= *b;
+}
+
+int main() {
+    using Unsigned = Aeu<128>;
+    using Signed = Aesi<128>;
+
+    /* Unsigned */
+    Unsigned h_ua = 100u, h_ub = 200u, h_uc = 0u;
+
+    Unsigned* d_ua = nullptr, *d_ub = nullptr, *d_uc = nullptr;
+    cudaMalloc(&d_ua, sizeof(Unsigned));
+    cudaMalloc(&d_ub, sizeof(Unsigned));
+    cudaMalloc(&d_uc, sizeof(Unsigned));
+    cudaMemcpy(d_ua, &h_ua, sizeof(Unsigned), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_ub, &h_ub, sizeof(Unsigned), cudaMemcpyHostToDevice);
+
+    unsignedKernel<128><<<1, 1>>>(d_ua, d_ub, d_uc);
+
+    cudaMemcpy(&h_uc, d_uc, sizeof(Unsigned), cudaMemcpyDeviceToHost);
+    cudaFree(d_ua); cudaFree(d_ub); cudaFree(d_uc);
+
+    /* Signed */
+    Signed h_sa = -50, h_sb = 75, h_sc = 0;
+
+    Signed* d_sa = nullptr, *d_sb = nullptr, *d_sc = nullptr;
+    cudaMalloc(&d_sa, sizeof(Signed));
+    cudaMalloc(&d_sb, sizeof(Signed));
+    cudaMalloc(&d_sc, sizeof(Signed));
+    cudaMemcpy(d_sa, &h_sa, sizeof(Signed), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_sb, &h_sb, sizeof(Signed), cudaMemcpyHostToDevice);
+
+    signedKernel<128><<<1, 1>>>(d_sa, d_sb, d_sc);
+
+    cudaMemcpy(&h_sc, d_sc, sizeof(Signed), cudaMemcpyDeviceToHost);
+    cudaFree(d_sa); cudaFree(d_sb); cudaFree(d_sc);
+
+    return 0;
+}

--- a/include/AesiMultiprecision/Aesi.h
+++ b/include/AesiMultiprecision/Aesi.h
@@ -729,19 +729,19 @@ public:
         /**
          * @brief Oldstyle comparison operator(s). Used inside CUDA cause it does not support <=> operator.
          */
-        gpu constexpr auto operator!=(const Aeu& value) const noexcept -> bool {
+        gpu constexpr auto operator!=(const Aeu<bitness>& value) const noexcept -> bool {
             return !this->operator==(value);
         }
-        gpu constexpr auto operator<(const Aeu& value) const noexcept -> bool {
+        gpu constexpr auto operator<(const Aeu<bitness>& value) const noexcept -> bool {
             return this->compareTo(value) == Comparison::less;
         }
-        gpu constexpr auto operator<=(const Aeu& value) const noexcept -> bool {
+        gpu constexpr auto operator<=(const Aeu<bitness>& value) const noexcept -> bool {
             return !this->operator>(value);
         }
-        gpu constexpr auto operator>(const Aeu& value) const noexcept -> bool {
+        gpu constexpr auto operator>(const Aeu<bitness>& value) const noexcept -> bool {
             return this->compareTo(value) == Comparison::greater;
         }
-        gpu constexpr auto operator>=(const Aeu& value) const noexcept -> bool {
+        gpu constexpr auto operator>=(const Aeu<bitness>& value) const noexcept -> bool {
             return !this->operator<(value);
         }
 #else

--- a/include/AesiMultiprecision/Aesi.h
+++ b/include/AesiMultiprecision/Aesi.h
@@ -79,18 +79,18 @@ public:
     /**
      * @brief Default constructor
      */
-    gpu constexpr Aesi() noexcept = default;
+    constexpr Aesi() noexcept = default;
 
     /**
      * @brief Destructor
      */
-    gpu constexpr ~Aesi() noexcept = default;
+    constexpr ~Aesi() noexcept = default;
 
     /**
      * @brief Copy constructor
      * @param copy Aesi&
      */
-    gpu constexpr Aesi(const Aesi& copy) noexcept = default;
+    constexpr Aesi(const Aesi& copy) noexcept = default;
 
     /**
      * @brief Integral constructor
@@ -183,7 +183,7 @@ public:
      * @brief Copy assignment operator
      * @param other Aesi&
      */
-    gpu constexpr Aesi& operator=(const Aesi& other) noexcept = default;
+    constexpr Aesi& operator=(const Aesi& other) noexcept = default;
     /* ----------------------------------------------------------------------- */
 
 

--- a/include/AesiMultiprecision/Aeu.h
+++ b/include/AesiMultiprecision/Aeu.h
@@ -139,23 +139,23 @@ public:
     /**
      * @brief Default constructor
      */
-    gpu constexpr Aeu() noexcept = default;
+    constexpr Aeu() noexcept = default;
 
     /**
      * @brief Destructor
      */
-    gpu constexpr ~Aeu() noexcept = default;
+    constexpr ~Aeu() noexcept = default;
 
     /**
      * @brief Copy constructor
      */
-    gpu constexpr Aeu(const Aeu& copy) noexcept = default;
+    constexpr Aeu(const Aeu& copy) noexcept = default;
 
     /**
      * @brief Copy assignment operator
      * @param other Aeu
      */
-    gpu constexpr Aeu& operator=(const Aeu& other) = default;
+    constexpr Aeu& operator=(const Aeu& other) = default;
 
     /**
      * @brief Integral constructor


### PR DESCRIPTION
Adds smoke.cu and CMake project under ci/cuda/ to verify the library compiles with nvcc. Runs in nvidia/cuda:12.6.0-devel-ubuntu24.04 container targeting sm_80, no GPU required.